### PR TITLE
Remove Response::HTTP_BAD_REQUEST for symfony 2.3 compatibility

### DIFF
--- a/src/Qandidate/Common/Symfony/HttpKernel/EventListener/JsonRequestTransformerListener.php
+++ b/src/Qandidate/Common/Symfony/HttpKernel/EventListener/JsonRequestTransformerListener.php
@@ -32,7 +32,7 @@ class JsonRequestTransformerListener
         }
 
         if (! $this->transformJsonBody($request)) {
-            $response = Response::create('Unable to parse request.', Response::HTTP_BAD_REQUEST);
+            $response = Response::create('Unable to parse request.', 400);
             $event->setResponse($response);
         }
     }

--- a/src/Qandidate/Common/Symfony/HttpKernel/EventListener/JsonRequestTransformerListener.php
+++ b/src/Qandidate/Common/Symfony/HttpKernel/EventListener/JsonRequestTransformerListener.php
@@ -20,6 +20,8 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
  */
 class JsonRequestTransformerListener
 {
+    private $jsonContentTypes = ['json', 'application/json'];
+
     /**
      * @param GetResponseEvent $event
      */
@@ -39,7 +41,7 @@ class JsonRequestTransformerListener
 
     private function isJsonRequest(Request $request)
     {
-        return 'json' === $request->getContentType();
+        return in_array($request->getContentType(), $this->jsonContentTypes);
     }
 
     private function transformJsonBody(Request $request)

--- a/src/Qandidate/Common/Symfony/HttpKernel/EventListener/JsonRequestTransformerListener.php
+++ b/src/Qandidate/Common/Symfony/HttpKernel/EventListener/JsonRequestTransformerListener.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
  */
 class JsonRequestTransformerListener
 {
-    private $jsonContentTypes = ['json', 'application/json'];
+    private $jsonContentTypes = array('json', 'application/json');
 
     /**
      * @param GetResponseEvent $event


### PR DESCRIPTION
In older symfony versions Response::HTTP_BAD_REQUEST doesn't exist. 

I don't think the status code 400 will change in the short term, so I guess we can use the number,

I've also added application/json to the content type check.

Cheers
