### PR TITLE
Use prefer-lowest when running against 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
 
 before_script:
   - composer require symfony/http-kernel:${SYMFONY_VERSION}
+  - if [[ "$SYMFONY_VERSION" == "2.3.*" ]]; then composer update --prefer-lowest; fi
 
 script:
   - phpunit


### PR DESCRIPTION
We had an issue with HttpFoundation 2.3 in #2.
With this PR we test against the lowest dependency matrix.

Only when testing against Symfony 2.3, I don't think it makes a lot of sense to do this for each version.
