### PR TITLE
Fix null request content

### DIFF
--- a/src/Qandidate/Common/Symfony/HttpKernel/EventListener/JsonRequestTransformerListener.php
+++ b/src/Qandidate/Common/Symfony/HttpKernel/EventListener/JsonRequestTransformerListener.php
@@ -27,6 +27,10 @@ class JsonRequestTransformerListener
     {
         $request = $event->getRequest();
 
+        if (empty($request->getContent())) {
+            return;
+        }
+
         if (! $this->isJsonRequest($request)) {
             return;
         }

--- a/test/Qandidate/Common/Symfony/HttpKernel/EventListener/JsonRequestTransformerListenerTest.php
+++ b/test/Qandidate/Common/Symfony/HttpKernel/EventListener/JsonRequestTransformerListenerTest.php
@@ -39,6 +39,7 @@ class JsonRequestTransformerListenerTest extends PHPUnit_Framework_TestCase
             $data,
             $event->getRequest()->request->all()
         );
+        $this->assertNull($event->getResponse());
     }
 
     public function jsonContentTypes()
@@ -74,6 +75,7 @@ class JsonRequestTransformerListenerTest extends PHPUnit_Framework_TestCase
         $this->listener->onKernelRequest($event);
 
         $this->assertEquals($request, $event->getRequest());
+        $this->assertNull($event->getResponse());
     }
 
     /**
@@ -87,6 +89,7 @@ class JsonRequestTransformerListenerTest extends PHPUnit_Framework_TestCase
         $this->listener->onKernelRequest($event);
 
         $this->assertEquals($request, $event->getRequest());
+        $this->assertNull($event->getResponse());
     }
 
     /**
@@ -100,6 +103,7 @@ class JsonRequestTransformerListenerTest extends PHPUnit_Framework_TestCase
         $this->listener->onKernelRequest($event);
 
         $this->assertEquals($request, $event->getRequest());
+        $this->assertNull($event->getResponse());
     }
 
     public function notJsonContentTypes()


### PR DESCRIPTION
If the request has an empty content the json is invalid and a 400 response is created. So I think it should be added a condition to ignore requests with empty content, no matter if the content type is json.
