### PR TITLE
Return immediately if request is not json

### DIFF
--- a/src/Qandidate/Common/Symfony/HttpKernel/EventListener/JsonRequestTransformerListener.php
+++ b/src/Qandidate/Common/Symfony/HttpKernel/EventListener/JsonRequestTransformerListener.php
@@ -27,13 +27,13 @@ class JsonRequestTransformerListener
     {
         $request = $event->getRequest();
 
+        if (! $this->isJsonRequest($request)) {
+            return;
+        }
+        
         $content = $request->getContent();
 
         if (empty($content)) {
-            return;
-        }
-
-        if (! $this->isJsonRequest($request)) {
             return;
         }
 


### PR DESCRIPTION
Fetching the contents before this checkick if the request is json may result in OutOfMemory excpetion if the request is multipart and contains big files.

Sample exception excerpt:

```
OutOfMemoryException in Request.php line 1564:
Error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 67108888 bytes)
in Request.php line 1564
at file_get_contents() in Request.php line 1564
at Request->getContent() in JsonRequestTransformerListener.php line 30
at JsonRequestTransformerListener->onKernelRequest() in WrappedListener.php line 106
```

Checking if request contains json content type headers before fetching the contents prevents this error.