### PR TITLE
Compatibility with Symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "qandidate/symfony-json-request-transformer",
-  "description": "A Symfony 2 event listener for decoding JSON encoded request content",
+  "description": "A Symfony event listener for decoding JSON encoded request content",
   "license": "MIT",
   "authors": [
     {
@@ -13,7 +13,7 @@
     }
   ],
   "require": {
-    "symfony/http-kernel": "~2.3|~3.0"
+    "symfony/http-kernel": "~2.3|~3.0|~4.0"
   },
   "autoload": {
     "psr-0": {


### PR DESCRIPTION
Hi, I wanted to use the library with Symfony 4, but it turned out it supports ~2.3 and ~3.0 only. This is a quick fix to make it working with ~4.0.