### PR TITLE
drop Symfony 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 7.4
 
 env:
-  - SYMFONY_VERSION=3.4.*
   - SYMFONY_VERSION=4.4.*
   - SYMFONY_VERSION=5.0.*
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     }
   ],
   "require": {
-    "symfony/http-kernel": "^3.4||^4.4|^5.0"
+    "symfony/http-kernel": "^4.4|^5.0"
   },
   "autoload": {
     "psr-0": {


### PR DESCRIPTION
because GetResponseEvent was renamed in 4.3: https://symfony.com/blog/new-in-symfony-4-3-simpler-event-dispatching