### PR TITLE
Fix bc break

### DIFF
--- a/src/JsonRequestTransformerListener.php
+++ b/src/JsonRequestTransformerListener.php
@@ -51,7 +51,15 @@ class JsonRequestTransformerListener
     {
         $data = json_decode((string) $request->getContent(), true);
 
-        if (JSON_ERROR_NONE !== json_last_error() || !is_array($data)) {
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            return false;
+        }
+
+        if (is_null($data) || is_bool($data)) {
+            return true;
+        }
+
+        if (!is_array($data)) {
             return false;
         }
 

--- a/test/JsonRequestTransformerListenerTest.php
+++ b/test/JsonRequestTransformerListenerTest.php
@@ -104,6 +104,28 @@ class JsonRequestTransformerListenerTest extends TestCase
         ];
     }
 
+    /**
+     * @test
+     * @dataProvider provideValidNonStructuredJson
+     */
+    public function it_also_accepts_valid_json_if_its_not_structured_content($body): void
+    {
+        $request = $this->createRequest('application/json', $body);
+        $event = $this->createGetResponseEventMock($request);
+
+        $this->listener->onKernelRequest($event);
+        $this->assertNull($event->getResponse());
+    }
+
+    public static function provideValidNonStructuredJson()
+    {
+        return [
+            'boolean true' => ['true'],
+            'boolean false' => ['false'],
+            'null' => ['null'],
+        ];
+    }
+
     private function createRequest($contentType, $body)
     {
         $request = new Request([], [], [], [], [], [], $body);


### PR DESCRIPTION
Fix for #53 

With strict typing and an upgrade of PHPStan we broke previously working behaviour, where `null` would be accepted as valid JSON but wouldn't replace any values. This PR introduces the same behaviour again.
The same goes for booleans now, where earlier this would probably have broken the Symfony parameter back by replacing the whole thing with a boolean 😅 yay for strict types.