### PR TITLE
Update README to reflect archive status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 symfony-json-request-transformer
 ================================
 
+> 🚨 This repository is archived as it has served its purpose.
+> Symfony has built-in support for this: https://symfony.com/doc/current/components/http_foundation.html#accessing-request-data
+>
+> ```$request->getPayload()->get('foo');```
+
 A Symfony event listener for decoding JSON encoded request content.
 
 ![build status](https://github.com/qandidate-labs/symfony-json-request-transformer/actions/workflows/ci.yml/badge.svg)


### PR DESCRIPTION
Symfony added support for JSON in two ways, which makes this library in my opinion obsolete.

In Symfony 5.2 `$request->toArray()` was added, which allows direct access to a parsed JSON request body. This on it's own did not replace this library yet, as it didn't provide the benefits of the parameter bag. 

But in Symfony 6.3 `$request->getPayload()` was also added. This returns an `InputBag` (which extends ParameterBag). Giving you the same-ish interface as this library provided.

Instead of `$request->request->get('foo');` you now do `$request->getPayload()->get('foo')`.